### PR TITLE
Remove use of useFetchCargoVendor

### DIFF
--- a/packages/form.nix
+++ b/packages/form.nix
@@ -8,7 +8,6 @@ rustPlatform.buildRustPackage rec {
   pname = "form";
   version = "0.13.0";
 
-  useFetchCargoVendor = true;
   src = fetchCrate {
     inherit pname version;
     hash = "sha256-7+5HEyP7480UM5dydavoiclX3YTvW46V8r+Vpqt4xWk=";

--- a/packages/mdbook-wavedrom.nix
+++ b/packages/mdbook-wavedrom.nix
@@ -8,7 +8,6 @@ rustPlatform.buildRustPackage rec {
   pname = "mdbook-wavedrom";
   version = "0.10.0";
 
-  useFetchCargoVendor = true;
   src = fetchCrate {
     inherit pname version;
     hash = "sha256-eGFDZQ71ofXeulsGdK6T8QUpgtEGbpqKIrbYKtFlUD0=";


### PR DESCRIPTION
useFetchCargoVendor is being deprecated and recommended for removal (https://github.com/NixOS/nixpkgs/commit/777cdc5a8b394f640f12992209ab3655eefa7cad)